### PR TITLE
Improve unit testing for escape code

### DIFF
--- a/test/escape.coffee
+++ b/test/escape.coffee
@@ -16,16 +16,16 @@ describe 'escape', ->
       """
       next()
 
-  it 'should honor the backslash escape charactere', (next) ->
+  it 'should honor the backslash escape characters', (next) ->
     stringify [
       [ '20322051544','19\"79.0','8.8017226E7','A\"B\"C','45','2000-01-01' ]
       [ '28392898392','1974.0','8.8392926E7','DEF','23','2050-11-27' ]
+      [ '28392898393','1975.0','8.8392927E7','GHI\\','24','2050-11-28' ]
     ], escape: '\\', eof: false, (err, data) ->
       return next err if err
       data.should.eql """
       20322051544,"19\\"79.0",8.8017226E7,"A\\"B\\"C",45,2000-01-01
       28392898392,1974.0,8.8392926E7,DEF,23,2050-11-27
+      28392898393,1975.0,8.8392927E7,GHI\\,24,2050-11-28
       """
       next()
-
-


### PR DESCRIPTION
When investigating an issue, I updated a unit test so it tests the code under a scenario which I thought I was encountering. The test passes, but we should probably make sure that we're validating that with custom escape characters, that escape character in the input is also escaped.