### PR TITLE
escape the escape character when quoting a field (rebased)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -207,7 +207,7 @@ Stringifier.prototype._transform = function(chunk, encoding, callback) {
 };
 
 Stringifier.prototype.stringify = function(line) {
-  var _line, column, columns, containsLinebreak, containsQuote, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, value;
+  var _line, column, columns, containsEscape, containsLinebreak, containsQuote, containsdelimiter, delimiter, escape, field, i, j, l, newLine, quote, ref, ref1, regexp, shouldQuote, value;
   if (typeof line !== 'object') {
     return line;
   }
@@ -254,12 +254,18 @@ Stringifier.prototype.stringify = function(line) {
       if (field) {
         containsdelimiter = field.indexOf(delimiter) >= 0;
         containsQuote = field.indexOf(quote) >= 0;
+        containsEscape = field.indexOf(escape) >= 0 && (escape !== quote);
         containsLinebreak = field.indexOf('\r') >= 0 || field.indexOf('\n') >= 0;
+        shouldQuote = containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string');
+        if (shouldQuote && containsEscape) {
+          regexp = escape === '\\' ? new RegExp(escape + escape, 'g') : new RegExp(escape, 'g');
+          field = field.replace(regexp, escape + escape);
+        }
         if (containsQuote) {
           regexp = new RegExp(quote, 'g');
           field = field.replace(regexp, escape + quote);
         }
-        if (containsQuote || containsdelimiter || containsLinebreak || this.options.quoted || (this.options.quotedString && typeof line[i] === 'string')) {
+        if (shouldQuote) {
           field = quote + field + quote;
         }
         newLine += field;

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -183,11 +183,16 @@ Convert a line to a string. Line may be an object, an array or a string.
           if field
             containsdelimiter = field.indexOf(delimiter) >= 0
             containsQuote = field.indexOf(quote) >= 0
+            containsEscape = field.indexOf(escape) >= 0 and (escape isnt quote)
             containsLinebreak = field.indexOf('\r') >= 0 or field.indexOf('\n') >= 0
+            shouldQuote = containsQuote or containsdelimiter or containsLinebreak or @options.quoted or (@options.quotedString and typeof line[i] is 'string')
+            if shouldQuote and containsEscape
+              regexp = if escape is '\\' then new RegExp(escape + escape, 'g') else new RegExp(escape, 'g');
+              field = field.replace(regexp, escape + escape)
             if containsQuote
               regexp = new RegExp(quote,'g')
               field = field.replace(regexp, escape + quote)
-            if containsQuote or containsdelimiter or containsLinebreak or @options.quoted or (@options.quotedString and typeof line[i] is 'string')
+            if shouldQuote
               field = quote + field + quote
             newLine += field
           else if @options.quotedEmpty or (not @options.quotedEmpty? and line[i] is '' and @options.quotedString)

--- a/test/escape.coffee
+++ b/test/escape.coffee
@@ -21,11 +21,14 @@ describe 'escape', ->
       [ '20322051544','19\"79.0','8.8017226E7','A\"B\"C','45','2000-01-01' ]
       [ '28392898392','1974.0','8.8392926E7','DEF','23','2050-11-27' ]
       [ '28392898393','1975.0','8.8392927E7','GHI\\','24','2050-11-28' ]
+      [ 'escape char','and', 'quote char','in','source:','\\"' ] # actually \"
     ], escape: '\\', eof: false, (err, data) ->
       return next err if err
       data.should.eql """
       20322051544,"19\\"79.0",8.8017226E7,"A\\"B\\"C",45,2000-01-01
       28392898392,1974.0,8.8392926E7,DEF,23,2050-11-27
       28392898393,1975.0,8.8392927E7,GHI\\,24,2050-11-28
+      escape char,and,quote char,in,source:,"\\\\\\\""
       """
+      # for the "escape char and quote char" value we want: \\\"
       next()


### PR DESCRIPTION
Not trying to steal any credit here, just rebasing @waylonflinn's imho very important fix from #25 to current master in an attempt to get this merged, so we don't have to continue using our private fork.

Original Description:

check for the presence of an existing instance of the
given escape character in a field. if we're going to quote
that field then also escape the escape character.
this fixes round tripping (stringify followed by parser)
on data sets that already contain instances of the escape
character