### PR TITLE
add option for ISO date formatting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -246,6 +246,8 @@ Stringifier.prototype.stringify = function(line) {
         field = '' + field;
       } else if (typeof field === 'boolean') {
         field = field ? '1' : '';
+      } else if (field instanceof Date && this.options.dateFormat === 'ISO') {
+        field = '' + field.toISOString();
       } else if (field instanceof Date) {
         field = '' + field.getTime();
       } else if (typeof field === 'object' && field !== null) {

--- a/src/index.coffee.md
+++ b/src/index.coffee.md
@@ -174,6 +174,9 @@ Convert a line to a string. Line may be an object, an array or a string.
           else if typeof field is 'boolean'
             # Cast boolean to string
             field = if field then '1' else ''
+          else if field instanceof Date and @options.dateFormat is 'ISO'
+            # Cast date to ISO timestamp string
+            field = '' + field.toISOString()
           else if field instanceof Date
             # Cast date to timestamp string
             field = '' + field.getTime()

--- a/test/dateFormat.coffee
+++ b/test/dateFormat.coffee
@@ -1,0 +1,23 @@
+
+should = require 'should'
+stringify = if process.env.CSV_COV then require '../lib-cov' else require '../src'
+
+describe 'dateFormat', ->
+
+  it 'defaults to formatting as the getTime integer', (next) ->
+    stringify [
+      {field1: new Date('2016-01-01'), field2: 'val12', field3: 'val13'}
+      {field1: 'val21', field2: 'val22', field3: 'val23'}
+    ], (err, data) ->
+      return next err if err
+      data.should.eql '1451606400000,val12,val13\nval21,val22,val23\n'
+      next()
+
+  it 'can optionally format to ISO', (next) ->
+    stringify [
+      {field1: new Date('2016-01-01'), field2: 'val12', field3: 'val13'}
+      {field1: 'val21', field2: 'val22', field3: 'val23'}
+    ], dateFormat: 'ISO', (err, data) ->
+      return next err if err
+      data.should.eql '2016-01-01T00:00:00.000Z,val12,val13\nval21,val22,val23\n'
+      next()


### PR DESCRIPTION
My spreadsheet doesn't really know what to do with the `getTime()` integer from dates. `toISOString()` is an alternative that internationalizes well and is immediately human readable.

Not sure if this is the way you'd want to include it as an option but it's working for me.